### PR TITLE
build.sh: Fix duplicate resync step

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,13 +6,16 @@ rm -rf .repo/local_manifests
 #sync
 repo init -u https://github.com/RisingTechOSS/android -b fourteen --git-lfs --depth=1
 git clone https://github.com/Legendleo90/local_manifests.git -b rising .repo/local_manifests
-repo sync -c --no-clone-bundle --optimized-fetch --prune --force-sync -j$(nproc --all)
+if [ -f /opt/crave/resync.sh ]; then
+  /opt/crave/resync.sh
+else
+  repo sync -c --no-clone-bundle --optimized-fetch --prune --force-sync -j$(nproc --all)
+fi
 
 #ksu
 cd kernel/xiaomi/beryllium && curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash - && cd ../../..
 
 # build
-/opt/crave/resync.sh
 . build/envsetup.sh
 riseup beryllium user
 rise b


### PR DESCRIPTION
/opt/crave/resync.sh is a script used for resyncing. 

A simple if condition is attached so that it will work normally on non crave environments as long as repo is installed